### PR TITLE
Setting INLA calls to be verbose by default

### DIFF
--- a/R/predict_inla.R
+++ b/R/predict_inla.R
@@ -263,6 +263,7 @@ fit_inla_model <- function(df,
                                mdl <- INLA::inla(formula = formula,
                                                  data = x,
                                                  control.predictor = control.predictor,
+                                                 verbose = TRUE,
                                                  ...)
                                predict_inla_data(x,
                                                  mdl,

--- a/R/predict_inla_avg_trend.R
+++ b/R/predict_inla_avg_trend.R
@@ -270,6 +270,7 @@ fit_inla_average_model <- function(df,
                              mdl <- INLA::inla(formula = formula,
                                                data = x,
                                                control.predictor = control.predictor,
+                                               verbose = TRUE,
                                                ...)
                              predict_inla_data(x,
                                                mdl,


### PR DESCRIPTION
Force the `verbose` parameters to the `INLA` functions, thus allowing for better (if longer)  debugging.